### PR TITLE
Danbooru Video

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command: redis-server --requirepass ${REDIS_PASSWORD}
   
   psql:
-    image: postgres:alpine
+    image: postgres:16-alpine
     ports:
       - 5432:5432
     volumes:

--- a/src/KumaKaiNi.Client.Discord/Program.cs
+++ b/src/KumaKaiNi.Client.Discord/Program.cs
@@ -13,6 +13,8 @@ namespace KumaKaiNi.Client.Discord;
 
 internal static class Program
 {
+    private static readonly string[] VideoFileTypes = [ "mp4", "webm" ];
+
     private static RedisStreamConsumer? _streamConsumer;
     private static DiscordSocketClient? _discordClient;
     private static CancellationTokenSource? _cts;
@@ -257,6 +259,12 @@ internal static class Program
             await channel.SendMessageAsync(
                 text: kumaResponse.Message, 
                 embed: embed.Build(), 
+                options: _defaultDiscordRequestOptions);
+
+            if (!VideoFileTypes.Any(x => kumaResponse.Image.Url.EndsWith(x))) return;
+
+            await channel.SendMessageAsync(
+                text: $"[Video]({kumaResponse.Image.Url})",
                 options: _defaultDiscordRequestOptions);
         }
         // Send a standard message

--- a/src/KumaKaiNi.Core/Commands/DanbooruCommands.cs
+++ b/src/KumaKaiNi.Core/Commands/DanbooruCommands.cs
@@ -10,6 +10,7 @@ using KumaKaiNi.Core.Database.Entities;
 using KumaKaiNi.Core.Models;
 using KumaKaiNi.Core.Utility;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 namespace KumaKaiNi.Core.Commands;
 
@@ -149,7 +150,11 @@ public static class DanbooruCommands
             request.Headers.Authorization = authHeader;
             
             HttpResponseMessage response = await Rest.SendAsync(request);
-            if (!response.IsSuccessStatusCode) return null;
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Error("Response from Danbooru did not indicate success: {Response}", response);
+                return null;
+            }
             
             string content = await response.Content.ReadAsStringAsync();
             List<DanbooruResult>? results = JsonSerializer.Deserialize<List<DanbooruResult>>(content);

--- a/src/KumaKaiNi.Core/Commands/DanbooruCommands.cs
+++ b/src/KumaKaiNi.Core/Commands/DanbooruCommands.cs
@@ -19,8 +19,8 @@ public static class DanbooruCommands
     [Command("dan", nsfw: true)]
     public static async Task<KumaResponse> GetDanbooruAsync(KumaRequest kumaRequest)
     {
-        ResponseMedia? image = await GetDanbooruImageAsync(kumaRequest.CommandArgs, kumaRequest.SourceSystem, kumaRequest.ChannelId);
-        return image?.Url != null ? new KumaResponse { Media = image } : new KumaResponse("Nothing found!");
+        ResponseMedia? media = await GetDanbooruImageAsync(kumaRequest.CommandArgs, kumaRequest.SourceSystem, kumaRequest.ChannelId);
+        return media?.Url != null ? new KumaResponse { Media = media } : new KumaResponse("Nothing found!");
     }
 
     [Command(["safe", "sfw"])]
@@ -28,9 +28,9 @@ public static class DanbooruCommands
     {
         string[] baseTags = ["rating:g"];
         string[] requestTags = baseTags.Concat(kumaRequest.CommandArgs).ToArray();
-        ResponseMedia? image = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
+        ResponseMedia? media = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
 
-        return image?.Url != null ? new KumaResponse { Media = image } : new KumaResponse("Nothing found!");
+        return media?.Url != null ? new KumaResponse { Media = media } : new KumaResponse("Nothing found!");
     }
 
     [Command("lewd", nsfw: true)]
@@ -38,9 +38,9 @@ public static class DanbooruCommands
     {
         string[] baseTags = ["rating:q"];
         string[] requestTags = baseTags.Concat(kumaRequest.CommandArgs).ToArray();
-        ResponseMedia? image = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
+        ResponseMedia? media = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
 
-        return image?.Url != null ? new KumaResponse { Media = image } : new KumaResponse("Nothing found!");
+        return media?.Url != null ? new KumaResponse { Media = media } : new KumaResponse("Nothing found!");
     }
 
     [Command("xxx", nsfw: true)]
@@ -48,9 +48,9 @@ public static class DanbooruCommands
     {
         string[] baseTags = ["rating:e"];
         string[] requestTags = baseTags.Concat(kumaRequest.CommandArgs).ToArray();
-        ResponseMedia? image = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
+        ResponseMedia? media = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
 
-        return image?.Url != null ? new KumaResponse { Media = image } : new KumaResponse("Nothing found!");
+        return media?.Url != null ? new KumaResponse { Media = media } : new KumaResponse("Nothing found!");
     }
 
     [Command("nsfw", nsfw: true)]
@@ -58,9 +58,9 @@ public static class DanbooruCommands
     {
         string[] baseTags = [Rng.PickRandom(["rating:q", "rating:e"])];
         string[] requestTags = baseTags.Concat(kumaRequest.CommandArgs).ToArray();
-        ResponseMedia? image = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
+        ResponseMedia? media = await GetDanbooruImageAsync(requestTags, kumaRequest.SourceSystem, kumaRequest.ChannelId);
 
-        return image?.Url != null ? new KumaResponse { Media = image } : new KumaResponse("Nothing found!");
+        return media?.Url != null ? new KumaResponse { Media = media } : new KumaResponse("Nothing found!");
     }
     
     [Command("danban", UserAuthority.Administrator)]

--- a/src/KumaKaiNi.Core/Models/KumaResponse.cs
+++ b/src/KumaKaiNi.Core/Models/KumaResponse.cs
@@ -14,7 +14,7 @@ public class KumaResponse
     /// The response image.
     /// </summary>
     [JsonPropertyName("image")]
-    public ResponseImage? Image  { get; set; }
+    public ResponseMedia? Media  { get; set; }
 
     /// <summary>
     /// The system the message request came from.
@@ -52,27 +52,27 @@ public class KumaResponse
     /// <summary>
     /// Object used for responding to requests.
     /// </summary>
-    /// <param name="image">The response image.</param>
-    public KumaResponse(ResponseImage image)
+    /// <param name="media">The response media.</param>
+    public KumaResponse(ResponseMedia media)
     {
         Message = "";
-        Image = image;
+        Media = media;
     }
 
     /// <summary>
     /// Object used for responding to requests.
     /// </summary>
     /// <param name="message">The response message.</param>
-    /// <param name="image">The response image.</param>
-    public KumaResponse(string? message, ResponseImage image)
+    /// <param name="media">The response media.</param>
+    public KumaResponse(string? message, ResponseMedia media)
     {
         Message = message;
-        Image = image;
+        Media = media;
     }
 
     public override string? ToString()
     {
-        if (string.IsNullOrEmpty(Message) && Image != null) return Image.Source;
+        if (string.IsNullOrEmpty(Message) && Media != null) return Media.Source;
         return Message;
     }
 }

--- a/src/KumaKaiNi.Core/Models/ResponseMedia.cs
+++ b/src/KumaKaiNi.Core/Models/ResponseMedia.cs
@@ -9,13 +9,19 @@ namespace KumaKaiNi.Core.Models;
 /// <param name="source">Where the image was found.</param>
 /// <param name="description">Description of the image.</param>
 /// <param name="referrer">The host of the image.</param>
-public class ResponseImage(string url, string source, string description, string referrer)
+public class ResponseMedia(string url, string preview, string source, string description, string referrer)
 {
     /// <summary>
-    /// The direct URL to the image.
+    /// The direct URL to the media.
     /// </summary>
     [JsonPropertyName("url")]
     public string Url { get; set; } = url;
+
+    /// <summary>
+    /// The direct URL to the media.
+    /// </summary>
+    [JsonPropertyName("preview")]
+    public string Preview { get; set; } = preview;
 
     /// <summary>
     /// Where the image was found.

--- a/src/KumaKaiNi.Core/Utility/Logging.cs
+++ b/src/KumaKaiNi.Core/Utility/Logging.cs
@@ -47,8 +47,8 @@ public static class Logging
         await using KumaKaiNiDbContext db = new();
 
         string? responseString = kumaResponse.Message;
-        if (string.IsNullOrEmpty(responseString) && kumaResponse.Image != null) 
-            responseString = $"{kumaResponse.Image.Referrer}\n{kumaResponse.Image.Description}\n{kumaResponse.Image.Url}\n{kumaResponse.Image.Source}";
+        if (string.IsNullOrEmpty(responseString) && kumaResponse.Media != null) 
+            responseString = $"{kumaResponse.Media.Referrer}\n{kumaResponse.Media.Description}\n{kumaResponse.Media.Url}\n{kumaResponse.Media.Source}";
 
         if (!string.IsNullOrEmpty(responseString))
         {


### PR DESCRIPTION
- Core: Renamed `ResponseImage` to `ResponseMedia`
- Core: Added `Preview` field to `ResponseMedia`
- Core: Added error logging for Danbooru API failures
- Core Added IsDeleted check in Danbooru 
- Core: Modifed Danbooru description string
- Discord: Implemented mp4 and webm embeds via https://autocompressor.net/av1
- Telegram: Implemented mp4 embeds
- Telegram: Modified image messages to send preview images when media is too large

Resolves #35 